### PR TITLE
introduces the ability to turn off the plugin with single flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ ManifestGuard Gradle plugin is aimed to solve this issue for you. For every buil
 ## Setup
 ManifestGuard is applicable only to Android application modules because for libraries it does not make any sense. The setup is easy, just add the plugin to `plugins` blocks in your application's `build.gradle`:
 ```groovy
-plugins {  
-	id 'com.android.application'
-	id 'kotlin-android'
-	id 'com.dpforge.manifestguard' version 'x.x.x'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'com.dpforge.manifestguard' version 'x.x.x'
 }
 ```
 Basically that's it. But you can configure the plugin depending on your needs. Take a look at the next section.
@@ -25,14 +25,16 @@ Basically that's it. But you can configure the plugin depending on your needs. T
 Plugin has default settings but you can change them in the following way:
 ```groovy
 manifestGuard {
-	referenceFile = new File(projectDir, "manifest/original.xml")
-	htmlDiffFile = new File(projectDir, "manifest-diff.html")
-	ignore {
-		ignoreAppVersionChanges true
-	}
+    enabled = shouldEnabledManifestGuard()
+    referenceFile = new File(projectDir, "manifest/original.xml")
+    htmlDiffFile = new File(projectDir, "manifest-diff.html")
+    ignore {
+        ignoreAppVersionChanges true
+    }
 }
 ```
 
+* `enabled` - whether plugin enabled or not. By default it's enabled;
 * `referenceFile` - path to the file which is treated like a reference `AndroidManifest.xml`. It means that this file is going to be compared with new merged manifest during next build. The default file is `GuardedAndroidManifest.xml` placed in the root of the project;
 * `htmlDiffFile` - path to the file where HTML report will be written when there are differences between two manifests;
 * `ignore` - configuration of ignore options

--- a/gradle-plugin/src/main/java/com/dpforge/manifestguard/ManifestGuardExtension.kt
+++ b/gradle-plugin/src/main/java/com/dpforge/manifestguard/ManifestGuardExtension.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import java.io.Serializable
 import javax.inject.Inject
 
@@ -11,6 +12,9 @@ abstract class ManifestGuardExtension @Inject constructor(
     objects: ObjectFactory,
     layout: ProjectLayout
 ) {
+
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
     val referenceFile: RegularFileProperty = objects.fileProperty().convention(
         layout.projectDirectory.file(
             "GuardedAndroidManifest.xml"

--- a/gradle-plugin/src/main/java/com/dpforge/manifestguard/ManifestGuardPlugin.kt
+++ b/gradle-plugin/src/main/java/com/dpforge/manifestguard/ManifestGuardPlugin.kt
@@ -2,6 +2,7 @@ package com.dpforge.manifestguard
 
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.AppPlugin
 import org.gradle.api.Plugin
@@ -20,25 +21,35 @@ class ManifestGuardPlugin : Plugin<Project> {
                 project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
 
             androidComponents.onVariants { variant ->
-                val taskProvider = project.tasks.register(
-                    "compare${variant.capitalizedName()}MergedManifest",
-                    CompareMergedManifestTask::class.java,
-                ) { task ->
-                    task.referenceManifestFile.set(extension.referenceFile)
-                    task.htmlDiffFile.set(extension.htmlDiffFile)
-                    task.ignoreConfig.set(extension.ignore)
+                if (extension.enabled.get()) {
+                    handleApplicationVariant(project, variant, extension)
                 }
-
-                // The task is registered as artifact transformer because it's the only way not to rely on
-                // implementation details (like merge task name or type)
-                variant.artifacts.use(taskProvider)
-                    .wiredWithFiles(
-                        CompareMergedManifestTask::mergedManifestFileIn,
-                        CompareMergedManifestTask::mergedManifestFileOut,
-                    )
-                    .toTransform(SingleArtifact.MERGED_MANIFEST)
             }
         }
+    }
+
+    private fun handleApplicationVariant(
+        project: Project,
+        variant: ApplicationVariant,
+        extension: ManifestGuardExtension
+    ) {
+        val taskProvider = project.tasks.register(
+            "compare${variant.capitalizedName()}MergedManifest",
+            CompareMergedManifestTask::class.java,
+        ) { task ->
+            task.referenceManifestFile.set(extension.referenceFile)
+            task.htmlDiffFile.set(extension.htmlDiffFile)
+            task.ignoreConfig.set(extension.ignore)
+        }
+
+        // The task is registered as artifact transformer because it's the only way not to rely on
+        // implementation details (like merge task name or type)
+        variant.artifacts.use(taskProvider)
+            .wiredWithFiles(
+                CompareMergedManifestTask::mergedManifestFileIn,
+                CompareMergedManifestTask::mergedManifestFileOut,
+            )
+            .toTransform(SingleArtifact.MERGED_MANIFEST)
     }
 
     private fun Variant.capitalizedName(): String = name.replaceFirstChar { it.uppercaseChar() }

--- a/gradle-plugin/src/test/java/com/dpforge/manifestguard/ManifestGuardPluginTest.kt
+++ b/gradle-plugin/src/test/java/com/dpforge/manifestguard/ManifestGuardPluginTest.kt
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -144,6 +145,23 @@ class ManifestGuardPluginTest {
         assertEquals(TaskOutcome.FAILED, result.compareDebugMergedManifestOutcome())
         assertTrue(result.output.contains("AndroidManifests are different"))
         assertTrue(defaultHtmlDiffFile.exists())
+    }
+
+    @Test
+    fun `compare - has changes but plugin is disabled`() {
+        generator.generate {
+            manifestGuardExtension =
+                """
+                    manifestGuard {
+                       enabled = false
+                    }
+                """.trimIndent()
+        }
+
+        val result = assembleTestApp()
+
+        assertNull(result.task(":test-app:compareDebugMergedManifest"))
+        assertFalse(defaultReferenceFile.exists())
     }
 
     private fun modifyDefaultReferenceLabel() {


### PR DESCRIPTION
This PR introduces flag `enabled` which makes it possible to turn off manifest-guard. Maybe useful to enable the plugin only on CI for instance.